### PR TITLE
Resolve merge conflict in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=builder /install /usr/local
 COPY backend/ ./backend
 
 # Static frontend bundle
-COPY --from=frontend-builder /opt/frontend_build/dist ./frontend_build # Updated to use `dist` directory as specified in `next.config.js`
+# Next.js with `output: 'export'` writes the static site to the `out/` directory
+# regardless of any `distDir` setting. Copy that folder so FastAPI can serve it.
+COPY --from=frontend-builder /opt/frontend_build/out ./frontend_build
 
 CMD ["bash", "-c", "uvicorn backend.main:app --host 0.0.0.0 --port $PORT"]


### PR DESCRIPTION
## Summary
- clean up static bundle copy command in Dockerfile

## Testing
- `ruff check .`
- `pytest backend/quick_config_test.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'supabase')*


------
https://chatgpt.com/codex/tasks/task_e_6848ad24fa34833187c083ac44ac3ba4